### PR TITLE
Implemented #revenue method in #merchant to take a date as parameter. Me...

### DIFF
--- a/lib/merchants.rb
+++ b/lib/merchants.rb
@@ -25,7 +25,14 @@ class Merchants
   end
 
   def revenue(date = nil)
-    successful_invoices.reduce(0) do |revenue, invoice|
+    #if a date is passed, then select the invoices that are only from that dat
+    #then do math
+    if date
+      invoice_pool = successful_invoices.select { |invoice| invoice.updated_at == date }
+    else
+      invoice_pool = successful_invoices
+    end
+    invoice_pool.reduce(0) do |revenue, invoice|
       revenue + invoice.total_amount_billed
     end
   end

--- a/test/merchants_test.rb
+++ b/test/merchants_test.rb
@@ -36,4 +36,8 @@ class MerchantsTest < Minitest::Test
     assert_equal 'BigDecimal', @merchant.revenue
   end
 
+  def test_it_finds_total_revenue_for_given_date
+    assert_equal 'bigDecimal', @merchant.revenue('"2012-03-25 13:54:11 UTC"')
+  end
+
 end


### PR DESCRIPTION
...thod still fails to select invoices that are only updated_at on the given date, otherwise, if no date is passed, #revenue method works. Have not implemented BigDecimal formatting yet
